### PR TITLE
Directly reference arrays in grid metrics

### DIFF
--- a/gridtools/gridutils.py
+++ b/gridtools/gridutils.py
@@ -541,8 +541,8 @@ class GridUtils(object):
         R = self.getRadius(self.gridInfo['gridParameters'])
 
         # Make a copy of the lon grid as values are changed for computation
-        lon = self.grid.x.copy()
-        lat = self.grid.y
+        lon = self.grid.x.copy().data
+        lat = self.grid.y.data
 
         # Approximate edge lengths as great arcs
         self.grid['dx'] = (('nyp', 'nx'),  R * spherical.angle_through_center( (lat[ :,1:],lon[ :,1:]), (lat[:  ,:-1],lon[:  ,:-1]) ))


### PR DESCRIPTION
The lat/lon arrays on a grid are actually DataArrays, and they cannot be used to define derived arrays in the `computeGridMetricsSpherical` routine. By referencing the underlying numpy arrays, the computation can proceed as expected.

It might also be worth removing a bunch of the commented-out code from this routine, and exercising `computeGridMetricsSpherical` in the test suite. I could do this if it's of interest too!